### PR TITLE
Revert title generation to gpt4

### DIFF
--- a/src/shared/aiTypesAndMappers.ts
+++ b/src/shared/aiTypesAndMappers.ts
@@ -13,10 +13,6 @@ export enum ChatAuthor {
 
 export enum OpenAiModelEnum {
   GPT3_5_TURBO = 'openai/gpt-3.5-turbo',
-  GPT4 = 'openai/gpt-4-turbo-preview',
-}
-
-export const OpenaiModelToHuman: Record<OpenAiModelEnum, string> = {
-  [OpenAiModelEnum.GPT3_5_TURBO]: 'ChatGPT 3.5 Turbo',
-  [OpenAiModelEnum.GPT4]: 'ChatGPT 4',
+  GPT4 = 'openai/gpt-4',
+  GPT4_TURBO = 'openai/gpt-4-turbo-preview',
 }


### PR DESCRIPTION
### Problem
- Random throws in production of clients using their own OpenAI api keys, with "gpt-4-turbo-preview" not enabled. According to OpenAI forums, it's either a bug or customers who have never made a deposit do not have access to the preview.

<img width="1582" alt="image" src="https://github.com/joiahq/joia/assets/6229037/bb758815-832b-4866-bfd0-95d96d53367c">

### Solution
revert to gpt-4, non turbo